### PR TITLE
Fix install.sh sourced-invocation and stale template alias

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,10 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Refuse sourced or non-bash invocation: zsh leaves BASH_SOURCE unset, misplacing the venv.
+if [[ -z "${BASH_VERSION:-}" ]]; then
+  printf 'error: scripts/install.sh must be executed with bash, not sourced. Run: ./scripts/install.sh\n' >&2
+  return 1 2>/dev/null || exit 1
+fi
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  printf 'error: scripts/install.sh must be executed, not sourced. Run: ./scripts/install.sh\n' >&2
+  return 1 2>/dev/null || exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUNNER_VENV="$REPO_ROOT/.opengauss-installer-venv"
-DEFAULT_INSTALL_TARGET="opengauss"
+# Prefer the checked-in template: the shared `opengauss` alias at morph.new has been observed to 404.
+LOCAL_TEMPLATE_YAML="$REPO_ROOT/.github/morph/opengauss-template.yaml"
+if [ -f "$LOCAL_TEMPLATE_YAML" ]; then
+  DEFAULT_INSTALL_TARGET="$LOCAL_TEMPLATE_YAML"
+else
+  DEFAULT_INSTALL_TARGET="opengauss"
+fi
 INSTALL_TARGET="${OPEN_GAUSS_INSTALL_TARGET:-${OPEN_GAUSS_TEMPLATE_TARGET:-$DEFAULT_INSTALL_TARGET}}"
 DEFAULT_SESSION_NAME="gauss"
 SESSION_NAME="${OPEN_GAUSS_SESSION_NAME:-$DEFAULT_SESSION_NAME}"


### PR DESCRIPTION
## Summary
- Refuse sourced or non-bash invocation of `scripts/install.sh` — sourcing from zsh (`. ./scripts/install.sh`) silently misplaced the installer venv one directory above the repo root because zsh leaves `BASH_SOURCE` unset, causing `SCRIPT_DIR` to collapse to cwd. Guard fires before any path resolution and uses `return` when sourced, `exit` otherwise, so it never kills the user's interactive shell.
- Prefer the checked-in `.github/morph/opengauss-template.yaml` as the default install target — the shared `opengauss` alias at `morph.new` has been observed returning `404 Not Found`, breaking `--experimental-run-locally` runs that fall through to the remote fetch. Since anyone who `git clone`s the repo always has the tracked YAML on disk, this makes local installs fully self-contained.
- All existing env-var overrides (`OPEN_GAUSS_INSTALL_TARGET`, `OPEN_GAUSS_TEMPLATE_TARGET`) are preserved; the change only swaps the default when nothing is set.

## Test plan
- [x] `bash -n scripts/install.sh` — syntax valid
- [x] `zsh -c '. ./scripts/install.sh'` — refused with clear error, no venv created
- [x] `bash -c 'source ./scripts/install.sh'` — refused with clear error
- [x] Full fresh install via `./scripts/install.sh` completed end-to-end on macOS arm64 (Python 3.13, zsh host shell, no tmux) — all 9 template steps succeeded, `gauss` binary landed at `~/.local/bin/gauss`, `~/.gauss` populated, Lean workspace + mathlib4 cache downloaded.
- [ ] CI / contributor review on Linux and Windows (WSL2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)